### PR TITLE
#1059 change sleep logic for fetching metrics; added tests; encode ti…

### DIFF
--- a/lib/dynatrace/dynatrace.go
+++ b/lib/dynatrace/dynatrace.go
@@ -121,9 +121,6 @@ func (ph *Handler) GetSLIValue(metric string, start string, end string, customFi
 
 	timeseriesQueryString, err := ph.getTimeseriesConfig(metric)
 
-	// split query string by first occurance of "?"
-	timeseriesIdentifier := strings.Split(timeseriesQueryString, "?")[0]
-
 	if err != nil {
 		fmt.Printf("Error when fetching timeseries config: %s\n", err.Error())
 		return 0, err
@@ -132,7 +129,16 @@ func (ph *Handler) GetSLIValue(metric string, start string, end string, customFi
 	// replace query params
 	timeseriesQueryString = ph.replaceQueryParameters(timeseriesQueryString)
 
-	targetUrl := ph.ApiURL + fmt.Sprintf("/api/v2/metrics/series/%s", url.QueryEscape(timeseriesQueryString))
+	// split query string by first occurance of "?"
+	timeseriesIdentifier := strings.Split(timeseriesQueryString, "?")[0]
+
+	timeseriesIdentifierEncoded := url.QueryEscape(timeseriesIdentifier)
+
+	timeseriesQueryString = strings.Replace(timeseriesQueryString, timeseriesIdentifier, timeseriesIdentifierEncoded, 1)
+
+	fmt.Printf("Old=%s, new=%s\n", timeseriesIdentifier, timeseriesIdentifierEncoded)
+
+	targetUrl := ph.ApiURL + fmt.Sprintf("/api/v2/metrics/series/%s", timeseriesQueryString)
 
 	queryParams := map[string]string{
 		"resolution": "Inf", // resolution=Inf means that we only get 1 datapoint (per service)

--- a/main.go
+++ b/main.go
@@ -106,11 +106,13 @@ func retrieveMetrics(event cloudevents.Event) error {
 	dynatraceAPIUrl, apiToken, err := getProjectDynatraceCredentials(kubeClient, stdLogger, eventData.Project)
 
 	if err != nil {
+		stdLogger.Debug(err.Error())
 		stdLogger.Debug("Failed to fetch dynatrace credentials for project, falling back to global credentials...")
 		// fallback to global dynatrace credentials (e.g., installed for dynatrace service)
 		dynatraceAPIUrl, apiToken, err = getGlobalDynatraceCredentials(kubeClient, stdLogger)
 
 		if err != nil {
+			stdLogger.Debug(err.Error())
 			stdLogger.Debug("Failed to fetch global dynatrace credentials as well... exiting.")
 			return err
 		}


### PR DESCRIPTION
- Special chars for timeseries names need to be encoded (e.g., `some.metric:filter(/api)` needs to be encoded - see https://play.golang.org/p/EsBo9WFUdyc
- Checks for start/end datetime added (+ tests)
- Sleep logic improved