### PR TITLE
Improve logging for secrets

### DIFF
--- a/releasenotes/releasenotes_develop.md
+++ b/releasenotes/releasenotes_develop.md
@@ -2,9 +2,11 @@
 
 ## New Features
 
+- Improved logging for fetching dynatrace secrets [#50](https://github.com/keptn-contrib/dynatrace-sli-service/pull/50)
 
 ## Fixed Issues
 
+- Error when using secret format from-file (as described in README) [#51](https://github.com/keptn-contrib/dynatrace-sli-service/issues/51)
  
 ## Known Limitations
 


### PR DESCRIPTION
With this PR I improved logging for fetching secrets.

Example Log Output if no credentials are defined:
```
{"timestamp":"2020-05-14T06:27:54.504173716Z","logLevel":"INFO","message":"Retrieving Dynatrace timeseries metrics"}
{"timestamp":"2020-05-14T06:27:54.505399284Z","logLevel":"INFO","message":"Loading dynatrace.conf.yaml"}
{"timestamp":"2020-05-14T06:27:54.547881835Z","logLevel":"DEBUG","message":"No Keptn Resource found: musicshop/hardening/catalogue/dynatrace/dynatrace.conf.yaml - {\"code\":404,\"message\":\"Project resource not found\"}\n"}
{"timestamp":"2020-05-14T06:27:54.548008813Z","logLevel":"INFO","message":"Trying to fetch secret containing Dynatrace credentials with name ''"}
{"timestamp":"2020-05-14T06:27:54.548031994Z","logLevel":"INFO","message":"Trying to fetch secret containing Dynatrace credentials with name 'dynatrace-credentials-musicshop'"}
{"timestamp":"2020-05-14T06:27:54.559305103Z","logLevel":"ERROR","message":"Error fetching secret containing Dynatrace credentials with name 'dynatrace-credentials-musicshop': secrets \"dynatrace-credentials-musicshop\" not found"}
{"timestamp":"2020-05-14T06:27:54.559404658Z","logLevel":"INFO","message":"Trying to fetch secret containing Dynatrace credentials with name 'dynatrace-credentials'"}
{"timestamp":"2020-05-14T06:27:54.562476678Z","logLevel":"ERROR","message":"Error fetching secret containing Dynatrace credentials with name 'dynatrace-credentials': secrets \"dynatrace-credentials\" not found"}
{"timestamp":"2020-05-14T06:27:54.562580859Z","logLevel":"INFO","message":"Trying to fetch secret containing Dynatrace credentials with name 'dynatrace'"}
{"timestamp":"2020-05-14T06:27:54.571603287Z","logLevel":"ERROR","message":"Error fetching secret containing Dynatrace credentials with name 'dynatrace': secrets \"dynatrace\" not found"}
{"timestamp":"2020-05-14T06:27:54.571698792Z","logLevel":"ERROR","message":"No Dynatrace credentials found in namespace keptn"}
{"timestamp":"2020-05-14T06:27:54.5717185Z","logLevel":"DEBUG","message":"Couldn't find any dynatrace specific secrets in namespace keptn"}
{"timestamp":"2020-05-14T06:27:54.571730932Z","logLevel":"DEBUG","message":"Failed to fetch Dynatrace credentials, exiting."}
```