### PR TITLE
Fix reviewdog missing linter

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,13 +5,22 @@ jobs:
     name: reviewdog
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+      - name: Add $GOPATH/bin
+        run: |
+          echo ::add-path::$(go env GOPATH)/bin
       - name: Check out code.
         uses: actions/checkout@v1
+      - name: Install linters
+        run: '( mkdir linters && cd linters && go get golang.org/x/lint/golint )'
       - name: Setup reviewdog
         run: |
           mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
           echo ::add-path::$HOME/bin
-          echo ::add-path::$(go env GOPATH)/bin # for Go projects
       - name: Run reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -9,4 +9,4 @@ runner:
     errorformat:
       - "%f:%l %m"
   govet:
-    cmd: go vet -all .
+    cmd: go vet -all ./...


### PR DESCRIPTION
Fix reviewdog missing the golint linter.

In addition, for `go vet` we have to make sure to include also the sub-directories using `./...`