### PR TITLE
#2195 Removed hard-coded URL for configuration service

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -451,24 +451,17 @@ func getDynatraceCredentials(secretName string, project string, logger *keptn.Lo
 
 	for _, secret := range secretNames {
 		logger.Info(fmt.Sprintf("Trying to fetch secret containing Dynatrace credentials with name '%s'", secret))
-		dtCredentials, err := common.GetDTCredentials(secret)
-
-		// write in log if fetching Dynatrace Credentials failed
-		if err != nil {
-			logger.Error(fmt.Sprintf("Error fetching secret containing Dynatrace credentials with name '%s': %s", secret, err.Error()))
-		}
+		dtCredentials, _ := common.GetDTCredentials(secret, logger)
 
 		if dtCredentials != nil {
 			// lets validate if the tenant URL is
-
-			logger.Info(fmt.Sprintf(" -> credentials found, returning (%s) ...", dtCredentials.Tenant))
+			logger.Info(fmt.Sprintf("Secret with credentials found, returning (%s) ...", dtCredentials.Tenant))
 			return dtCredentials, nil
 		}
 	}
+	logger.Error("No Dynatrace credentials found")
 
-	logger.Error("No Dynatrace credentials found in namespace keptn")
-
-	return nil, errors.New("Couldn't find any dynatrace specific secrets in namespace keptn")
+	return nil, errors.New("Could not find any Dynatrace specific secrets")
 }
 
 /**

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -266,7 +266,7 @@ func retrieveMetrics(event cloudevents.Event) error {
 	dtCredentials, err := getDynatraceCredentials(dtCreds, eventData.Project, stdLogger)
 
 	if err != nil {
-		stdLogger.Debug(err.Error())
+		stdLogger.Error(err.Error())
 		stdLogger.Debug("Failed to fetch Dynatrace credentials, exiting.")
 		// Implementing: https://github.com/keptn-contrib/dynatrace-sli-service/issues/49
 		return sendInternalGetSLIDoneEvent(shkeptncontext, eventData.Project, eventData.Service, eventData.Stage,
@@ -451,7 +451,12 @@ func getDynatraceCredentials(secretName string, project string, logger *keptn.Lo
 
 	for _, secret := range secretNames {
 		logger.Info(fmt.Sprintf("Trying to fetch secret containing Dynatrace credentials with name '%s'", secret))
-		dtCredentials, _ := common.GetDTCredentials(secret, logger)
+		dtCredentials, err := common.GetDTCredentials(secret)
+
+		// write in log if fetching Dynatrace Credentials failed
+		if err != nil {
+			logger.Error(fmt.Sprintf("Error fetching secret containing Dynatrace credentials with name '%s': %s", secret, err.Error()))
+		}
 
 		if dtCredentials != nil {
 			// lets validate if the tenant URL is
@@ -459,7 +464,6 @@ func getDynatraceCredentials(secretName string, project string, logger *keptn.Lo
 			return dtCredentials, nil
 		}
 	}
-	logger.Error("No Dynatrace credentials found")
 
 	return nil, errors.New("Could not find any Dynatrace specific secrets")
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -254,7 +254,7 @@ func parseDynatraceConfigFile(input []byte) (*DynatraceConfigFile, error) {
 /**
  * Pulls the Dynatrace Credentials from the passed secret
  */
-func GetDTCredentials(dynatraceSecretName string, logger *keptn.Logger) (*DTCredentials, error) {
+func GetDTCredentials(dynatraceSecretName string) (*DTCredentials, error) {
 	if dynatraceSecretName == "" {
 		return nil, nil
 	}
@@ -272,7 +272,6 @@ func GetDTCredentials(dynatraceSecretName string, logger *keptn.Logger) (*DTCred
 		secret, err := kubeAPI.CoreV1().Secrets(namespace).Get(dynatraceSecretName, metav1.GetOptions{})
 
 		if err != nil {
-			logger.Error(fmt.Sprintf("Error fetching secret %s from namespace %s : %s", dynatraceSecretName, namespace, err.Error()))
 			return nil, err
 		}
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -133,10 +133,10 @@ func ReplaceKeptnPlaceholders(input string, keptnEvent *BaseKeptnEvent) string {
 }
 
 func GetConfigurationServiceURL() string {
-	if os.Getenv("CONFIGURATION_SERVICE_URL") != "" {
-		return os.Getenv("CONFIGURATION_SERVICE_URL")
+	if os.Getenv("CONFIGURATION_SERVICE") != "" {
+		return os.Getenv("CONFIGURATION_SERVICE")
 	}
-	return "configuration-service.keptn.svc.cluster.local:8080"
+	return "configuration-service:8080"
 }
 
 //
@@ -254,7 +254,7 @@ func parseDynatraceConfigFile(input []byte) (*DynatraceConfigFile, error) {
 /**
  * Pulls the Dynatrace Credentials from the passed secret
  */
-func GetDTCredentials(dynatraceSecretName string) (*DTCredentials, error) {
+func GetDTCredentials(dynatraceSecretName string, logger *keptn.Logger) (*DTCredentials, error) {
 	if dynatraceSecretName == "" {
 		return nil, nil
 	}
@@ -272,6 +272,7 @@ func GetDTCredentials(dynatraceSecretName string) (*DTCredentials, error) {
 		secret, err := kubeAPI.CoreV1().Secrets(namespace).Get(dynatraceSecretName, metav1.GetOptions{})
 
 		if err != nil {
+			logger.Error(fmt.Sprintf("Error fetching secret %s from namespace %s : %s", dynatraceSecretName, namespace, err.Error()))
 			return nil, err
 		}
 


### PR DESCRIPTION
In course of testing this service in a namespace other than `keptn` a hard-coded URL has been found. 
This URL is changed by this PR. 