### PR TITLE
fixing yaml parsing + add dtcreds value as label

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -259,11 +259,20 @@ func retrieveMetrics(event cloudevents.Event) error {
 		dtCreds = dynatraceConfigFile.DtCreds
 		stdLogger.Debug("Found dynatrace.conf.yaml with DTCreds: " + dtCreds)
 	} else {
+		stdLogger.Debug("Using default DTCreds: dynatrace as no custom dynatrace.conf.yaml was found!")
 		dynatraceConfigFile = &common.DynatraceConfigFile{}
 		dynatraceConfigFile.Dashboard = ""
 		dynatraceConfigFile.DtCreds = "dynatrace"
 	}
 	dtCredentials, err := getDynatraceCredentials(dtCreds, eventData.Project, stdLogger)
+
+	//
+	// grabnerandi - Aug 26th 2020
+	// Adding DtCreds as a label so users know which DtCreds was used
+	if eventData.Labels == nil {
+		eventData.Labels = make(map[string]string)
+	}
+	eventData.Labels["DtCreds"] = dynatraceConfigFile.DtCreds
 
 	if err != nil {
 		stdLogger.Error(err.Error())
@@ -377,6 +386,8 @@ func retrieveMetrics(event cloudevents.Event) error {
 		err = errors.New("Couldnt retrieve any SLI Results")
 	}
 
+	//
+
 	return sendInternalGetSLIDoneEvent(shkeptncontext, eventData.Project, eventData.Service, eventData.Stage,
 		sliResults, eventData.Start, eventData.End, eventData.TestStrategy, eventData.DeploymentStrategy,
 		eventData.Deployment, eventData.Labels, eventData.Indicators, err)
@@ -450,6 +461,10 @@ func getDynatraceCredentials(secretName string, project string, logger *keptn.Lo
 	secretNames := []string{secretName, fmt.Sprintf("dynatrace-credentials-%s", project), "dynatrace-credentials", "dynatrace"}
 
 	for _, secret := range secretNames {
+		if secret == "" {
+			continue
+		}
+
 		logger.Info(fmt.Sprintf("Trying to fetch secret containing Dynatrace credentials with name '%s'", secret))
 		dtCredentials, err := common.GetDTCredentials(secret)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -258,6 +258,14 @@ func retrieveMetrics(event cloudevents.Event) error {
 	if dynatraceConfigFile != nil {
 		dtCreds = dynatraceConfigFile.DtCreds
 		stdLogger.Debug("Found dynatrace.conf.yaml with DTCreds: " + dtCreds)
+
+		//
+		// grabnerandi - Aug 26th 2020
+		// Adding DtCreds as a label so users know which DtCreds was used
+		if eventData.Labels == nil {
+			eventData.Labels = make(map[string]string)
+		}
+		eventData.Labels["DtCreds"] = dynatraceConfigFile.DtCreds
 	} else {
 		stdLogger.Debug("Using default DTCreds: dynatrace as no custom dynatrace.conf.yaml was found!")
 		dynatraceConfigFile = &common.DynatraceConfigFile{}
@@ -265,14 +273,6 @@ func retrieveMetrics(event cloudevents.Event) error {
 		dynatraceConfigFile.DtCreds = "dynatrace"
 	}
 	dtCredentials, err := getDynatraceCredentials(dtCreds, eventData.Project, stdLogger)
-
-	//
-	// grabnerandi - Aug 26th 2020
-	// Adding DtCreds as a label so users know which DtCreds was used
-	if eventData.Labels == nil {
-		eventData.Labels = make(map[string]string)
-	}
-	eventData.Labels["DtCreds"] = dynatraceConfigFile.DtCreds
 
 	if err != nil {
 		stdLogger.Error(err.Error())

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/cloudevents/sdk-go v0.10.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.6.0 // indirect

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -207,9 +207,9 @@ func GetDynatraceConfig(keptnEvent *BaseKeptnEvent, logger *keptn.Logger) (*Dyna
 		// loaded an empty file
 		logger.Debug("Content of dynatrace.conf.yaml is empty!")
 		return nil, nil
-	} else {
-		logger.Debug("Content of dynatrace.conf.yaml: " + dynatraceConfFileContent)
 	}
+
+	logger.Debug("Content of dynatrace.conf.yaml: " + dynatraceConfFileContent)
 
 	// unmarshal the file
 	dynatraceConfFile, err := parseDynatraceConfigFile([]byte(dynatraceConfFileContent))

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	keptnmodels "github.com/keptn/go-utils/pkg/api/models"
 	keptnapi "github.com/keptn/go-utils/pkg/api/utils"
@@ -60,7 +60,16 @@ type BaseKeptnEvent struct {
 	Labels map[string]string
 }
 
-var namespace = os.Getenv("POD_NAMESPACE")
+var namespace = getPodNamespace()
+
+func getPodNamespace() string {
+	ns := os.Getenv("POD_NAMESPACE")
+	if ns == "" {
+		return "keptn"
+	}
+
+	return ns
+}
 
 func GetKubernetesClient() (*kubernetes.Clientset, error) {
 	if RunLocal || RunLocalTest {
@@ -168,7 +177,7 @@ func GetKeptnResource(keptnEvent *BaseKeptnEvent, resourceURI string, logger *ke
 				// Lets search on PROJECT-LEVEL
 				keptnResourceContent, err = resourceHandler.GetProjectResource(keptnEvent.Project, resourceURI)
 				if err != nil || keptnResourceContent == nil || keptnResourceContent.ResourceContent == "" {
-					logger.Debug(fmt.Sprintf("No Keptn Resource found: %s/%s/%s/%s - %s", keptnEvent.Project, keptnEvent.Stage, keptnEvent.Service, resourceURI, err))
+					// logger.Debug(fmt.Sprintf("No Keptn Resource found: %s/%s/%s/%s - %s", keptnEvent.Project, keptnEvent.Stage, keptnEvent.Service, resourceURI, err))
 					return "", err
 				}
 
@@ -194,6 +203,14 @@ func GetDynatraceConfig(keptnEvent *BaseKeptnEvent, logger *keptn.Logger) (*Dyna
 		return nil, err
 	}
 
+	if dynatraceConfFileContent == "" {
+		// loaded an empty file
+		logger.Debug("Content of dynatrace.conf.yaml is empty!")
+		return nil, nil
+	} else {
+		logger.Debug("Content of dynatrace.conf.yaml: " + dynatraceConfFileContent)
+	}
+
 	// unmarshal the file
 	dynatraceConfFile, err := parseDynatraceConfigFile([]byte(dynatraceConfFileContent))
 
@@ -203,8 +220,8 @@ func GetDynatraceConfig(keptnEvent *BaseKeptnEvent, logger *keptn.Logger) (*Dyna
 		return nil, errors.New(logMessage)
 	}
 
-	logMessage := fmt.Sprintf("Loaded Config from dynatrace.conf.yaml:  %s", dynatraceConfFile)
-	logger.Info(logMessage)
+	// logMessage := fmt.Sprintf("Loaded Config from dynatrace.conf.yaml:  %s", dynatraceConfFile)
+	// logger.Info(logMessage)
 
 	return dynatraceConfFile, nil
 }

--- a/pkg/lib/dynatrace/dynatrace.go
+++ b/pkg/lib/dynatrace/dynatrace.go
@@ -976,6 +976,16 @@ func (ph *Handler) QueryDynatraceDashboardForSLIs(project string, stage string, 
 								// we use ":names" to find the right spot to add our custom dimension filter
 								dashboardSLI.Indicators[indicatorName] = strings.Replace(metricQuery, ":names", filterSLIDefinitionAggregatorValue, 1)
 
+								//
+								// grabnerandi - Aug 26th
+								// if passSLOs or warningSLOs are an empty list dont pass them at all. otherwise this will cause an issue with the lighthouse
+								if len(passSLOs) == 0 {
+									passSLOs = nil
+								}
+								if len(warningSLOs) == 0 {
+									warningSLOs = nil
+								}
+
 								// lets add the SLO definitin in case we need to generate an SLO.yaml
 								sloDefinition := &keptn.SLO{
 									SLI:     indicatorName,

--- a/sample/devopsfusionsamples/dynatrace.conf.yaml
+++ b/sample/devopsfusionsamples/dynatrace.conf.yaml
@@ -1,0 +1,3 @@
+---
+spec_version: '0.1.0'
+dtCreds: dyna-env2


### PR DESCRIPTION
This PR covers

1. Fixing a problem when loading dynatrace.conf.yaml. The YAML parser used was not able to correctly map the fields which led to issues. Now using the same YAML parser as the dynatrace-service
2. Implementing the request posted on the Keptn Repo - https://github.com/keptn/keptn/issues/2236: this adds the DtCreds value from dynatrace.conf.yaml as a label when the SLI service responds with its data
3. Optimized logging to avoid some confusion we have heard from users on the keptn slack
