### PR TITLE
Take entity type from metric definition not dashboard

### DIFF
--- a/pkg/lib/dynatrace/dynatrace.go
+++ b/pkg/lib/dynatrace/dynatrace.go
@@ -890,11 +890,18 @@ func (ph *Handler) QueryDynatraceDashboardForSLIs(project string, stage string, 
 				// TODO - handle aggregation rates -> probably doesnt make sense as we always evalute a short timeframe
 				// if series.AggregationRate
 
+				// lets get the true entity type as the one in the dashboard might not be accurate, e.g: IOT might be used instead of CUSTOM_DEVICE
+				// so - if the metric definition has EntityTypes defined we take the first one
+				entityType := series.EntityType
+				if len(metricDefinition.EntityType) > 0 {
+					entityType = metricDefinition.EntityType[0]
+				}
+
 				// lets create the metricSelector and entitySelector
 				// ATTENTION: adding :names so we also get the names of the dimensions and not just the entities. This means we get two values for each dimension
 				metricQuery := fmt.Sprintf("metricSelector=%s%s%s:%s:names;entitySelector=type(%s)%s",
 					series.Metric, mergeAggregator, filterAggregator, strings.ToLower(metricAggregation),
-					series.EntityType, managementZoneFilter)
+					entityType, managementZoneFilter)
 
 				// lets build the Dynatrace API Metric query for the proposed timeframe and additonal filters!
 				fullMetricQuery, metricID := ph.BuildDynatraceMetricsQuery(metricQuery, startUnix, endUnix, customFilters)


### PR DESCRIPTION
When a tool such as Neotys is sending external metrics to Dynatrace the Dynatrace-SLI-Service was not able to correctly form the required Metricsv2 Query from the Dynatrace SLO dashboard which resulted in Dynatrace-SLI-Service not being able to pull back any ext:* dynatrace metrics.
The problem was that the Dynatrace-SLI-Service was taking the Entity Type from the Dashboard definition - which - for external metrics - is incorrectly set to IOT. As the Dynatrace-SLI-Service queries the actual metric definition anyway the implementation just needs to take the Entity Type from the Metric Definition. This ensures that the Dynatrace-SLI-Service always uses the correct Entity Type when creating the metricsv2 query

This pull request is changing the implementation according to the problem described

The fix has already been tested during last weeks webinar with Neotys!