### PR TITLE
fixing parsing issue with pass/warn

### DIFF
--- a/pkg/lib/dynatrace/dynatrace.go
+++ b/pkg/lib/dynatrace/dynatrace.go
@@ -609,22 +609,34 @@ func ParsePassAndWarningFromString(customName string, defaultPass []string, defa
 	warnCriteria := []*keptn.SLOCriteria{}
 
 	for i := 0; i < len(nameValueSplits); i++ {
-		nameValueSplit := strings.Split(nameValueSplits[i], "=")
-		switch nameValueSplit[0] {
+		// need to adapt this in order to parse texts like this where we have an = in the expression itself - so we cant use this for the actual separation of name=value
+		// Response time (P95);sli=svc_rt_p95;pass=<+10%,<600
+		// Host Disk Queue Length (max);sli=host_disk_queue;pass=<=0;warning=<1;key=false
+
+		// nameValueSplit := strings.Split(nameValueSplits[i], "=")
+		nameValueDividerIndex := strings.Index(nameValueSplits[i], "=")
+		if nameValueDividerIndex < 0 {
+			continue
+		}
+
+		nameString := nameValueSplits[i][:nameValueDividerIndex]
+		valueString := nameValueSplits[i][nameValueDividerIndex+1:]
+		switch nameString /*nameValueSplit[0]*/ {
 		case "sli":
-			sliName = nameValueSplit[1]
+			// sliName = nameValueSplit[1]
+			sliName = valueString
 		case "pass":
 			passCriteria = append(passCriteria, &keptn.SLOCriteria{
-				Criteria: strings.Split(nameValueSplit[1], ","),
+				Criteria: strings.Split(valueString /*nameValueSplit[1]*/, ","),
 			})
 		case "warning":
 			warnCriteria = append(warnCriteria, &keptn.SLOCriteria{
-				Criteria: strings.Split(nameValueSplit[1], ","),
+				Criteria: strings.Split(valueString /*nameValueSplit[1]*/, ","),
 			})
 		case "key":
-			keySli, _ = strconv.ParseBool(nameValueSplit[1])
+			keySli, _ = strconv.ParseBool(valueString /*nameValueSplit[1]*/)
 		case "weight":
-			weight, _ = strconv.Atoi(nameValueSplit[1])
+			weight, _ = strconv.Atoi(valueString /*nameValueSplit[1]*/)
 		}
 	}
 

--- a/pkg/lib/dynatrace/dynatrace_test.go
+++ b/pkg/lib/dynatrace/dynatrace_test.go
@@ -156,6 +156,28 @@ func TestParsePassAndWarningFromString(t *testing.T) {
 			want3: 1,
 			want4: true,
 		},
+		{
+			name: "test with = in pass/warn expression",
+			args: args{
+				customName: "Host Disk Queue Length (max);sli=host_disk_queue;pass=<=0;warning=<1;key=false",
+			},
+			want:  "host_disk_queue",
+			want1: []*keptn.SLOCriteria{&keptn.SLOCriteria{Criteria: []string{"<=0"}}},
+			want2: []*keptn.SLOCriteria{&keptn.SLOCriteria{Criteria: []string{"<1"}}},
+			want3: 1,
+			want4: false,
+		},
+		{
+			name: "test weight",
+			args: args{
+				customName: "Host CPU %;sli=host_cpu;pass=<20;warning=<50;key=false;weight=2",
+			},
+			want:  "host_cpu",
+			want1: []*keptn.SLOCriteria{&keptn.SLOCriteria{Criteria: []string{"<20"}}},
+			want2: []*keptn.SLOCriteria{&keptn.SLOCriteria{Criteria: []string{"<50"}}},
+			want3: 2,
+			want4: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This fixes an issue with parsing pass and warning criteria from a dashboard.
In case the pass or warning contained an =, e.g: pass=<=0 - then the parsing was incorrect as the current implementation used to split the complete string by = instead of searching for the first occurrence of = and then parse the latter part separately

the code fix now addresses this issue