### PR TITLE
support for tilefilters

### DIFF
--- a/pkg/lib/dynatrace/dynatrace.go
+++ b/pkg/lib/dynatrace/dynatrace.go
@@ -930,14 +930,6 @@ func (ph *Handler) QueryDynatraceDashboardForSLIs(keptnEvent *common.BaseKeptnEv
 			continue
 		}
 
-		if tile.TileType == "SLO" {
-			// we will take the SLO definition from Dynatrace
-			for _, sloEntity := range tile.AssignedEntities {
-				ph.Logger.Debug(fmt.Sprintf("Processing SLO Definition: %s", sloEntity))
-			}
-			continue
-		}
-
 		// custom chart and usql have different ways to define their tile names - so - lets figure it out by looking at the potential values
 		tileTitle := tile.FilterConfig.CustomName // this is for all custom charts
 		if tileTitle == "" {

--- a/pkg/lib/dynatrace/dynatrace_test.go
+++ b/pkg/lib/dynatrace/dynatrace_test.go
@@ -276,6 +276,24 @@ func TestLoadDynatraceDashboardWithEmptyDashboard(t *testing.T) {
 	}
 }
 
+func TestGetEntitySelectorFromEntityFilter(t *testing.T) {
+	keptnEvent := testingGetKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE, "", "")
+	dh, _, _, teardown := testingGetDynatraceHandler(keptnEvent)
+	defer teardown()
+
+	var filtersPerEntityType = map[string]map[string][]string{
+		"SERVICE": map[string][]string{
+			"SPECIFIC_ENTITIES": []string{"SERVICE-086C46F600BA1DC6"},
+			"AUTO_TAGS":         []string{"keptn_deployment:primary"},
+		},
+	}
+	entityTileFilter := dh.GetEntitySelectorFromEntityFilter(filtersPerEntityType, "SERVICE")
+
+	if strings.Compare(entityTileFilter, ",entityId(\"SERVICE-086C46F600BA1DC6\"),tag(\"keptn_deployment:primary\")") != 0 {
+		t.Errorf("GetEntitySelectorFromEntityFilter wrong. Returned: " + entityTileFilter)
+	}
+}
+
 func TestQueryDynatraceDashboardForSLIs(t *testing.T) {
 	keptnEvent := testingGetKeptnEvent(QUALITYGATE_PROJECT, QUALITYGATE_STAGE, QUALTIYGATE_SERVICE, "", "")
 	dh, _, _, teardown := testingGetDynatraceHandler(keptnEvent)

--- a/pkg/lib/dynatrace/testfiles/test_get_dashboards_id.json
+++ b/pkg/lib/dynatrace/testfiles/test_get_dashboards_id.json
@@ -111,7 +111,15 @@
             ],
             "resultMetadata": {}
           },
-          "filtersPerEntityType": {}
+          "filtersPerEntityType": {               
+            "SERVICE": {
+              "SERVICE_TO_PG": ["PROCESS_GROUP-88C57C95F9A41B3C|keptn07project.simplenode.prod.primary"],
+              "SPECIFIC_ENTITIES": ["SERVICE-086C46F600BA1DC6"],
+              "SERVICE_SOFTWARE_TECH": ["NODE_JS"],
+              "SERVICE_TYPE": ["1"],
+              "AUTO_TAGS": ["keptn_deployment:primary"]
+            } 
+          }
         }
       },
       {


### PR DESCRIPTION
This closes #94 

The implementation now looks at the FiltersPerEntityType definition in the Dynatrace Dashboard JSON.
It currently supports both Tag and individual Entity filters. This means. If the chart includes a filter for e.g: all entities with a particular tag or a specific list of entities the Dynatrace SLI Service will correctly create the Dynatrace Metrics API v2 Query by including "tag" or "entityId" as part of the entitySelector

Here are two examples:
If the filter on the chart specifies only tags "keptn_project:myproject" then the query will look like
```
...&entitySelector=type(SERVICE),tags("keptn_project:myproject") ....
```

If the filter on the chart selects one or more entities, e.g: "myservice.frontend.staging" then the query will look like this including the entityId in the filter
```
...&entitySelector=type(SERVICE),entityID("SERVICE-1231232121312"),entityId("SERVICE-24343254343") ...
```