### PR TITLE
#206 Fix response time degradation in dynatrace-sli-service

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.13
+          go-version: ^1.16
       - name: Checkout Code
         uses: actions/checkout@v2
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.16
         id: go
       - name: Check out code.
         uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.13.7-alpine as builder
+FROM golang:1.16.2-alpine as builder
 
 RUN apk add --no-cache gcc libc-dev git
 
@@ -33,7 +33,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o dynatrac
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.11
+FROM alpine:3.13
 ENV ENV=production
 
 # Install extra packages

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keptn-contrib/dynatrace-sli-service
 
-go 1.13
+go 1.16
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.3.1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -22,7 +22,7 @@ deploy:
         overrides:
           distributor:
             image:
-              tag: 0.8.1
+              tag: 0.8.2
           resources:
             limits:
               memory: "512Mi"


### PR DESCRIPTION
Fixes #206  (+ update Go to 1.16).

I have moved the long-running parts of `retrieveMetrics` into a goroutine. This helps with avoiding getting a response time degradation:

![image](https://user-images.githubusercontent.com/56065213/117994956-377b3680-b341-11eb-87da-49dc174ec173.png)

Nevertheless, we need to look into our calls to configuration-service.