### PR TITLE
Patch/fix dynatrace config file parsing

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -45,8 +45,8 @@ const DynatraceConfigDashboardQUERY = "query"
 
 type DynatraceConfigFile struct {
 	SpecVersion string `json:"spec_version" yaml:"spec_version"`
-	DtCreds     string `json:"dtCreds",omitempty yaml:"dtCreds",omitempty`
-	Dashboard   string `json:"dashboard",omitempty yaml:"dashboard",omitempty`
+	DtCreds     string `json:"dtCreds,omitempty" yaml:"dtCreds,omitempty"`
+	Dashboard   string `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`
 }
 
 type DTCredentials struct {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseDynatraceConfigFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlString string
+		want       DynatraceConfigFile
+		wantErr    bool
+	}{
+		{
+			name:       "empty string",
+			yamlString: "",
+			want:       DynatraceConfigFile{},
+			wantErr:    false,
+		},
+		{
+			name: "valid yaml no dashboard",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna`,
+			want: DynatraceConfigFile{
+				SpecVersion: "0.1.0",
+				DtCreds:     "dyna"},
+			wantErr: false,
+		},
+		{
+			name: "valid yaml with dashboard",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna
+dashboard: dash`,
+			want: DynatraceConfigFile{
+				SpecVersion: "0.1.0",
+				DtCreds:     "dyna",
+				Dashboard:   "dash"},
+			wantErr: false,
+		},
+		{
+			name: "invalid yaml",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna,
+dashboard: ****`,
+			want:    DynatraceConfigFile{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDynatraceConfigFile(tt.yamlString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDynatraceConfigFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDynatraceConfigFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR:
- Fixes broken struct tags on `DynatraceConfigFile` to ensure the YAML parsing works
- Moves the parsing into `common.go` (hopefully we can eventually share this with the dynatrace-service)
- Simplifies the logic for parsing
- Adds some basic unit tests
