### PR TITLE
Patch/227/fix dynatrace config file parsing

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -244,6 +244,7 @@ func GetKeptnResource(keptnEvent *BaseKeptnEvent, resourceURI string) (string, e
 				log.WithFields(
 					log.Fields{
 						"resourceURI": resourceURI,
+						"project":     keptnEvent.Project,
 						"stage":       keptnEvent.Stage,
 					}).Debug("Found resource on stage level")
 			}
@@ -251,6 +252,8 @@ func GetKeptnResource(keptnEvent *BaseKeptnEvent, resourceURI string) (string, e
 			log.WithFields(
 				log.Fields{
 					"resourceURI": resourceURI,
+					"project":     keptnEvent.Project,
+					"stage":       keptnEvent.Stage,
 					"service":     keptnEvent.Service,
 				}).Debug("Found resource on service level")
 		}
@@ -369,12 +372,23 @@ func getBaseDynatraceConfig(keptnEvent *BaseKeptnEvent) DynatraceConfigFile {
 
 	yamlString, err := GetKeptnResource(keptnEvent, DynatraceConfigFilename)
 	if err != nil {
-		log.WithError(err).Debug("Error getting keptn resource")
+		log.WithError(err).WithFields(
+			log.Fields{
+				"service": keptnEvent.Service,
+				"stage":   keptnEvent.Stage,
+				"project": keptnEvent.Project,
+			}).Debug("Error getting keptn resource")
 		return defaultDynatraceConfigFile
 	}
 	dynatraceConfFile, err := parseDynatraceConfigFile(yamlString)
 	if err != nil {
-		log.WithError(err).WithField("yaml", yamlString).Error("Error parsing DynatraceConfigFile, using default configuration")
+		log.WithError(err).WithFields(
+			log.Fields{
+				"yaml":    yamlString,
+				"service": keptnEvent.Service,
+				"stage":   keptnEvent.Stage,
+				"project": keptnEvent.Project,
+			}).Error("Error parsing DynatraceConfigFile, using default configuration")
 		return defaultDynatraceConfigFile
 	}
 	return dynatraceConfFile

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 
 	keptnmodels "github.com/keptn/go-utils/pkg/api/models"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -46,8 +46,8 @@ const DynatraceConfigDashboardQUERY = "query"
 
 type DynatraceConfigFile struct {
 	SpecVersion string `json:"spec_version" yaml:"spec_version"`
-	DtCreds     string `json:"dtCreds",omitempty yaml:"dtCreds",omitempty`
-	Dashboard   string `json:"dashboard",omitempty yaml:"dashboard",omitempty`
+	DtCreds     string `json:"dtCreds,omitempty" yaml:"dtCreds,omitempty"`
+	Dashboard   string `json:"dashboard,omitempty" yaml:"dashboard,omitempty"`
 }
 
 type DTCredentials struct {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -20,7 +20,8 @@ func Test_parseDynatraceConfigFile(t *testing.T) {
 		},
 		{
 			name: "valid yaml no dashboard",
-			yamlString: `spec_version: '0.1.0'
+			yamlString: `
+spec_version: '0.1.0'
 dtCreds: dyna`,
 			want: DynatraceConfigFile{
 				SpecVersion: "0.1.0",
@@ -29,7 +30,8 @@ dtCreds: dyna`,
 		},
 		{
 			name: "valid yaml with dashboard",
-			yamlString: `spec_version: '0.1.0'
+			yamlString: `
+spec_version: '0.1.0'
 dtCreds: dyna
 dashboard: dash`,
 			want: DynatraceConfigFile{
@@ -40,7 +42,8 @@ dashboard: dash`,
 		},
 		{
 			name: "invalid yaml",
-			yamlString: `spec_version: '0.1.0'
+			yamlString: `
+spec_version: '0.1.0'
 dtCreds: dyna,
 dashboard: ****`,
 			want:    DynatraceConfigFile{},

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseDynatraceConfigFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlString string
+		want       DynatraceConfigFile
+		wantErr    bool
+	}{
+		{
+			name:       "empty string",
+			yamlString: "",
+			want:       DynatraceConfigFile{},
+			wantErr:    false,
+		},
+		{
+			name: "valid yaml no dashboard",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna`,
+			want: DynatraceConfigFile{
+				SpecVersion: "0.1.0",
+				DtCreds:     "dyna"},
+			wantErr: false,
+		},
+		{
+			name: "valid yaml with dashboard",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna
+dashboard: dash`,
+			want: DynatraceConfigFile{
+				SpecVersion: "0.1.0",
+				DtCreds:     "dyna",
+				Dashboard:   "dash"},
+			wantErr: false,
+		},
+		{
+			name: "invalid yaml",
+			yamlString: `spec_version: '0.1.0'
+dtCreds: dyna,
+dashboard: ****`,
+			want:    DynatraceConfigFile{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDynatraceConfigFile(tt.yamlString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDynatraceConfigFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDynatraceConfigFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -25,7 +25,8 @@ spec_version: '0.1.0'
 dtCreds: dyna`,
 			want: DynatraceConfigFile{
 				SpecVersion: "0.1.0",
-				DtCreds:     "dyna"},
+				DtCreds:     "dyna",
+			},
 			wantErr: false,
 		},
 		{
@@ -37,17 +38,31 @@ dashboard: dash`,
 			want: DynatraceConfigFile{
 				SpecVersion: "0.1.0",
 				DtCreds:     "dyna",
-				Dashboard:   "dash"},
+				Dashboard:   "dash",
+			},
 			wantErr: false,
 		},
 		{
 			name: "invalid yaml",
 			yamlString: `
 spec_version: '0.1.0'
-dtCreds: dyna,
+dtCreds: dyna
 dashboard: ****`,
 			want:    DynatraceConfigFile{},
 			wantErr: true,
+		},
+		{
+			name: "yaml with special characters",
+			yamlString: `
+spec_version: '0.1.0'
+dtCreds: dyna
+dashboard: '****'`,
+			want: DynatraceConfigFile{
+				SpecVersion: "0.1.0",
+				DtCreds:     "dyna",
+				Dashboard:   "****",
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This PR:

- Fixes the struct tags on `DynatraceConfigFile` to ensure the YAML parsing works
- Moves the parsing into `common.go`
- Adds some basic unit tests

The PR aims to leave the parsing logic unchanged: this will be addressed in a future issue.
